### PR TITLE
Fix #3: players[consoleplayer].camera can be null

### DIFF
--- a/zscript/SpriteShadow.zc
+++ b/zscript/SpriteShadow.zc
@@ -118,7 +118,7 @@ class Z_SpriteShadow : Actor
 				}
 				else
 				{
-					if (players[consoleplayer].camera.CheckLocalView(consoleplayer))
+					if (players[consoleplayer].camera && players[consoleplayer].camera.CheckLocalView(consoleplayer))
 					{
 						// hide shadow if you are under the monster
 						if (players[consoleplayer].camera.Pos.Z


### PR DESCRIPTION
Hello Nash, this is a problem I encountered as well in the same context: `players[consoleplayer].camera` can indeed be `null`, so simply guard against it.